### PR TITLE
Navigating back to main page after support page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,8 +18,6 @@ export default function Home() {
   const ref = useRef(null);
   const isInView = useInView(ref);
 
-  // const [scrollId, setScrollId]
-
   useEffect(() => {
     testExpressServer();
   }, []);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,8 @@ export default function Home() {
   const ref = useRef(null);
   const isInView = useInView(ref);
 
+  // const [scrollId, setScrollId]
+
   useEffect(() => {
     testExpressServer();
   }, []);
@@ -67,6 +69,18 @@ export default function Home() {
   const onMouseLeave = () => {
     setRotate({ x: 0, y: 0 });
   };
+
+  //checks hash and extracts id and scrolls to element associated with that id
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash) {
+      const id = hash.replace("#", "");
+      const element = document.getElementById(id);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, []);
 
   return (
     <>
@@ -208,7 +222,7 @@ export default function Home() {
         <About></About>
         <div
           className="text-left relative bg-gradient-to-b to-slate-950 from-transparent"
-          id="how it works"
+          id="how-it-works"
         >
           {/* <div className="bg-slate-950 h-[900px] absolute -top-36 -right-96 -left-96 -rotate-6 z-0"></div> */}
           <div className="px-6 max-w-7xl m-auto relative z-20 pt-40 pb-64 flex justify-between gap-20 items-center flex-col lg:flex-row">

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -68,20 +68,35 @@ const Nav = () => {
           ) : (
             <li
               className="hover:cursor-pointer transition hover:bg-opacity-10 bg-opacity-0 bg-white p-3 rounded-xl"
-              onClick={() => scrolltoHash("top")}
+              onClick={() => {
+                if (pathname.endsWith("/support")) {
+                  router.push("/")
+                }
+                scrolltoHash("top");
+              }}
             >
               Home
             </li>
           )}
           <li
             className="hover:cursor-pointer transition hover:bg-opacity-10 bg-opacity-0 bg-white p-3 rounded-xl"
-            onClick={() => scrolltoHash("features")}
+            onClick={() => {
+              if (pathname.endsWith("/support")) {
+                router.push("/#features")
+              }
+              scrolltoHash("features");
+            }}
           >
             Features
           </li>
           <li
             className="hover:cursor-pointer transition hover:bg-opacity-10 bg-opacity-0 bg-white p-3 rounded-xl"
-            onClick={() => scrolltoHash("how it works")}
+            onClick={() => {
+              if (pathname.endsWith("/support")) {
+                router.push("/#how-it-works");
+              }
+              scrolltoHash("how-it-works");
+            }}
           >
             How It Works
           </li>


### PR DESCRIPTION
There was no way to get back to the main page after getting to the support page so I added the functionality which takes you back scrolls to the correct location depending on which item is clicked on the nav bar.